### PR TITLE
Add file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/tasks.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -202,12 +203,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "lets-do-it"
 version = "0.1.0"
 dependencies = [
  "clap",
  "indexmap",
  "rustyline",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -322,6 +331,44 @@ dependencies = [
  "unicode-width",
  "utf8parse",
  "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,56 +3,6 @@
 version = 4
 
 [[package]]
-name = "anstream"
-version = "0.6.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,46 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,12 +28,6 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "endian-type"
@@ -171,12 +75,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,12 +95,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,10 +104,8 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "lets-do-it"
 version = "0.1.0"
 dependencies = [
- "clap",
  "indexmap",
  "rustyline",
- "serde",
  "serde_json",
 ]
 
@@ -263,12 +153,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "proc-macro2"
@@ -376,12 +260,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.41", features = ["derive"] }
 rustyline = "15.0.0"
-indexmap = "2.10.0"
+indexmap = { version = "2.2.6", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.5.41", features = ["derive"] }
 rustyline = "15.0.0"
 indexmap = { version = "2.2.6", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## What's this?
 Let's do it is a Rust CLI tool for your to-do tasks. 
 As of now, it doesn't have much uniqueness, its just your run-of-the-mill CLI to-do list.
-It does 
+It does now save your tasks in tasks.txt so they persist between runs!
 Simple functions:
 - Add
 - Update

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ## What's this?
 Let's do it is a Rust CLI tool for your to-do tasks. 
 As of now, it doesn't have much uniqueness, its just your run-of-the-mill CLI to-do list.
+It does 
 Simple functions:
 - Add
 - Update
@@ -17,10 +18,10 @@ or something like cargo run -- --list. I'll use clap (the library) for this.
 Check cargo.toml!  
 But right now, I use rustyline for input, and indexmap for well the IndexMap.
 
-<!-- Uncomment when you have made a release and maybe add a link!
+
 ## How can I use it?
-Just download the latest release for your OS from the Github Releases!  
+Just download the [latest release](https://github.com/Spacexplorer11/lets-do-it/releases/latest) for your OS from the Github Releases!  
 Rust compiles to native binaries making it super simple for you!
--->
+
 
 ## Please consider leaving a star

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,3 +201,11 @@ fn input(rl: &mut DefaultEditor) -> String {
         }
     }
 }
+
+fn save_tasks(tasks: &IndexMap<String, bool>) -> Result<(), Box<dyn std::error::Error>> {
+    const FILE_PATH: &str = "tasks.txt";
+    let json_string = serde_json::to_string_pretty(&tasks)?;
+    fs::write(FILE_PATH, json_string)?;
+    println!("Successfully saved tasks to {}", FILE_PATH);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,9 +215,16 @@ fn load_tasks() -> IndexMap<String, bool> {
     const FILE_PATH: &str = "tasks.txt";
     match fs::read_to_string(FILE_PATH) {
         Ok(json) => {
-            let data: IndexMap<String, bool> =
-                serde_json::from_str(&json).expect("Failed to parse JSON");
-            data
+            match serde_json::from_str(&json) {
+                Ok(data) => data,
+                Err(e) => {
+                    eprintln!(
+                        "Failed to parse saved tasks ({}). Starting with empty task list.",
+                        e
+                    );
+                    IndexMap::new()
+                }
+            }
         }
         Err(_) => {
             println!("No saved task file found, expected on first run");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ fn main() {
     let mut rl = DefaultEditor::new().unwrap();
     let mut tasks: IndexMap<String, bool> = IndexMap::new();
     let mut running = true;
+    const FILE_PATH: &str = "tasks.txt";
     const COMMANDS: [&str; 6] = [
         "add - adds a task",
         "list - lists the tasks",

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,9 @@ fn main() {
             }
         }
     }
-    save_tasks(&tasks).unwrap();
+    if let Err(e) = save_tasks(&tasks) {
+        eprintln!("Failed to save tasks: {}", e);
+    }
 }
 fn add_task(tasks: &mut IndexMap<String, bool>, rl: &mut DefaultEditor) -> bool {
     println!("Please enter the task name:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,3 +209,19 @@ fn save_tasks(tasks: &IndexMap<String, bool>) -> Result<(), Box<dyn std::error::
     println!("Successfully saved tasks to {}", FILE_PATH);
     Ok(())
 }
+
+fn load_tasks() -> IndexMap<String, bool> {
+    const FILE_PATH: &str = "tasks.txt";
+    match fs::read_to_string(FILE_PATH) {
+        Ok(json) => {
+            let data: IndexMap<String, bool> =
+                serde_json::from_str(&json).expect("Failed to parse JSON");
+            println!("Loaded tasks from {}:\n{:#?}", FILE_PATH, data);
+            data
+        }
+        Err(_) => {
+            println!("No saved task file found, expected on first run");
+            IndexMap::new()
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 use indexmap::IndexMap;
-use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
+use std::fs;
 
 fn main() {
     let mut rl = DefaultEditor::new().unwrap();
-    let mut tasks: IndexMap<String, bool> = IndexMap::new();
+    let mut tasks: IndexMap<String, bool> = load_tasks();
     let mut running = true;
-    const FILE_PATH: &str = "tasks.txt";
     const COMMANDS: [&str; 6] = [
         "add - adds a task",
         "list - lists the tasks",
@@ -57,6 +57,7 @@ fn main() {
             }
         }
     }
+    save_tasks(&tasks).unwrap();
 }
 fn add_task(tasks: &mut IndexMap<String, bool>, rl: &mut DefaultEditor) -> bool {
     println!("Please enter the task name:");
@@ -216,7 +217,6 @@ fn load_tasks() -> IndexMap<String, bool> {
         Ok(json) => {
             let data: IndexMap<String, bool> =
                 serde_json::from_str(&json).expect("Failed to parse JSON");
-            println!("Loaded tasks from {}:\n{:#?}", FILE_PATH, data);
             data
         }
         Err(_) => {


### PR DESCRIPTION
I added file support so the tasks can be saved & loaded, so they are preserved through multiple runs of Lets Do It!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task list is now automatically saved and loaded between runs, ensuring your tasks persist even after closing the app.

* **Bug Fixes**
  * Improved reliability of task storage and retrieval.

* **Chores**
  * Updated and adjusted dependencies for improved compatibility and performance.
  * Added `.gitignore` entry to exclude the task storage file from version control.
  * Enhanced documentation with updated usage instructions and release download links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->