### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release Let's Do It
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -228,6 +231,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build-macos, build-linux-windows]
     if: needs.build-linux-windows.outputs.should-release == 'true'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/4](https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/4)

To fix this problem, you should add an explicit `permissions` key at the workflow or job level to limit the permissions granted to the GITHUB_TOKEN in each job. The best practice is to set read-only access at the top level (`contents: read`) so that all jobs only have read access by default. Then, for jobs that need more permissions, such as creating releases, add a `permissions` block to that job granting just enough access (in this case, `contents: write` for the `release` job). This ensures the GITHUB_TOKEN is only granted the least privilege needed for each job.

Specifically:
- Add a `permissions` block at the top level (before or after `on:`) in `.github/workflows/release.yml`:
  ```yaml
  permissions:
    contents: read
  ```
- In the `release` job, add a job-level `permissions` block granting `contents: write`.

No changes are needed in the steps or other jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
