### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release Let's Do It
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -85,6 +88,8 @@ jobs:
 
   build-linux-windows:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       new-tag: ${{ steps.version.outputs.NEW_TAG }}
       should-release: ${{ steps.version.outputs.SHOULD_RELEASE }}
@@ -228,6 +233,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build-macos, build-linux-windows]
     if: needs.build-linux-windows.outputs.should-release == 'true'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/3](https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/3)

To address the issue, add a `permissions` block to the workflow. The recommended approach is to add it at the root so all jobs inherit the minimum required permissions (`contents: read`). For jobs that need write permissions (e.g., for creating releases or pushing tags), override the block at the job level and specify only the required permissions, such as `contents: write`. 

In this workflow, the `release` job (which uses `gh release create`) and any job that pushes tags (step "Push new tag" in `build-linux-windows`) need elevated permissions. Therefore:

1. Set `permissions: contents: read` at the root, so all jobs are restricted by default.
2. In `build-linux-windows`, set `permissions: contents: write` because the job pushes a tag.
3. In `release`, set `permissions: contents: write` (or more restricted if possible, but needed for release creation).

No other jobs require write access, so they inherit read-only permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow security by implementing improved permission configurations for build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->