### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/2](https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/2)

To fix the problem, you should add a `permissions` block specifying the minimal required privileges for the workflow. Since none of the jobs or steps need write-level permissions (they only build and test code), the minimal required permissions are `contents: read`. This block can be added either at the root of the workflow (recommended, as it applies to all jobs by default) or within individual jobs if more granular control is needed. The best way here is to add the following under the workflow name (after line 1), for clarity:  
```yaml
permissions:
  contents: read
```
This ensures that the workflow does not use excessive privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance security posture by implementing granular permission controls for repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->