### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release Let's Do It
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -228,6 +231,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [build-macos, build-linux-windows]
     if: needs.build-linux-windows.outputs.should-release == 'true'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/1](https://github.com/Spacexplorer11/lets-do-it/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block to the workflow, placed at the top-level (right after the `name` or `on` section) to apply least privilege to all jobs. For most build and artifact upload steps, only `contents: read` is required. For jobs or steps that actually create releases or push new tags, you may need `contents: write`. Since jobs are separated (`release` for creating the release, and possibly tag creation in `build-linux-windows`), you can set minimal `contents: read` at the workflow level, and then override per-job to `contents: write` only where needed.

Therefore:
- Add `permissions: contents: read` at the top of the workflow.
- Add `permissions: contents: write` to jobs performing write operations, specifically the `release` job. If another job pushes tags, add write permission there as well.

All changes are to be made in `.github/workflows/release.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration to enhance security controls in the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->